### PR TITLE
updated requirements, fixed line endings of assemblies.manifest.new

### DIFF
--- a/pyxamstore/explorer.py
+++ b/pyxamstore/explorer.py
@@ -494,16 +494,16 @@ def do_pack(in_json_config):
 
     # Write new assemblies.manifest
     print("Writing 'assemblies.manifest.new'...")
-    assemblies_manifest_f = open("assemblies.manifest.new", "w")
+    assemblies_manifest_f = open("assemblies.manifest.new", "w", newline='\n')
 
     assemblies_manifest_f.write("Hash 32     Hash 64             ")
-    assemblies_manifest_f.write("Blob ID  Blob idx  Name\r\n")
+    assemblies_manifest_f.write("Blob ID  Blob idx  Name\n")
 
     #for _, store_json in json_data['stores'].items():
     for assembly in json_data['assemblies']:
         hash32, hash64 = gen_xxhash(assembly['name'])
 
-        line = ("0x%08s  0x%016s  %03d      %04d      %s\r\n"
+        line = ("0x%08s  0x%016s  %03d      %04d      %s\n"
                 % (hash32, hash64, assembly['store_id'],
                    assembly['blob_idx'], assembly['name']))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-future==0.18.2
-lz4==2.2.1
-xxhash==2.0.2
+future==0.18.3
+lz4==4.3.2
+xxhash==3.2.0


### PR DESCRIPTION
On Windows the original version of pyxamstore created line endings `\r\r\n` (0x0D 0x0D 0x0A) which looked strange and most likely will not be accepted by Xamarin (not tested). 
The Xamarin app I was checking had only 0x0A in its `assemblies.manifest` so I would assume always just using `\n` is the best solution.